### PR TITLE
fix: handle missing padding in base64UrlDecode

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -279,6 +279,13 @@ class Authentication {
      * Base64 URL decode
      */
     private function base64UrlDecode($data) {
+        // A diferencia del base64 estándar, el formato URL-safe elimina los caracteres de padding
+        // '='. Si la longitud del string no es múltiplo de 4, base64_decode retornará false.
+        // Agregamos el padding necesario antes de decodificar para asegurar compatibilidad.
+        $remainder = strlen($data) % 4;
+        if ($remainder) {
+            $data .= str_repeat('=', 4 - $remainder);
+        }
         return base64_decode(strtr($data, '-_', '+/'));
     }
     


### PR DESCRIPTION
## Summary
- fix base64UrlDecode to add missing padding for proper decoding

## Testing
- `php -l auth.php`
- `php -l api.php`
- `php -r '$_SERVER["REQUEST_METHOD"]="GET"; ob_start(); include "auth.php"; ob_end_clean(); $ref = new ReflectionClass("Authentication"); $enc=$ref->getMethod("base64UrlEncode"); $enc->setAccessible(true); $dec=$ref->getMethod("base64UrlDecode"); $dec->setAccessible(true); $auth=new Authentication(); $encoded=$enc->invoke($auth,"hola"); echo "encoded=$encoded\n"; $decoded=$dec->invoke($auth,$encoded); echo "decoded=$decoded\n";'`

------
https://chatgpt.com/codex/tasks/task_b_68a77d592d58832da15f870a9fb6d04f